### PR TITLE
feat: allow facility to fulfill orders using DON prefix equivalent products

### DIFF
--- a/src/main/java/org/openlmis/referencedata/repository/OrderableRepository.java
+++ b/src/main/java/org/openlmis/referencedata/repository/OrderableRepository.java
@@ -111,6 +111,14 @@ public interface OrderableRepository extends
               + " AND o.productCode IN :productCodes")
   List<Orderable> findAllLatestByProductCode(@Param("productCodes") Iterable<Code> productCodes);
 
+  @Query(value =
+          "SELECT DISTINCT o FROM Orderable o"
+              + " WHERE (o.identity.id, o.identity.versionNumber)"
+              + " IN (SELECT identity.id, MAX(identity.versionNumber)"
+              + " FROM Orderable GROUP BY identity.id)"
+              + " AND UPPER(o.productCode) LIKE UPPER(:pattern)")
+  List<Orderable> findAllLatestByProductCodeLike(@Param("pattern") String pattern);
+
   @Query(value = SELECT_ORDERABLE
           + FROM_ORDERABLES_CLAUSE
           + WHERE_LATEST_ORDERABLE

--- a/src/main/java/org/openlmis/referencedata/web/OrderableFulfill.java
+++ b/src/main/java/org/openlmis/referencedata/web/OrderableFulfill.java
@@ -46,4 +46,9 @@ public final class OrderableFulfill {
     return new OrderableFulfill(canFulfillForMe, emptyList());
   }
 
+  public static OrderableFulfill of(List<UUID> canFulfillForMe,
+                                    List<UUID> canBeFulfilledByMe) {
+    return new OrderableFulfill(canFulfillForMe, canBeFulfilledByMe);
+  }
+
 }

--- a/src/main/java/org/openlmis/referencedata/web/OrderableFulfillFactory.java
+++ b/src/main/java/org/openlmis/referencedata/web/OrderableFulfillFactory.java
@@ -35,6 +35,7 @@ import org.slf4j.profiler.Profiler;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
+
 @Component
 public class OrderableFulfillFactory {
 
@@ -59,8 +60,12 @@ public class OrderableFulfillFactory {
       result = createForTradeItem(tradeItems, commodityTypes, tradeItemId, orderable, profiler);
     } else if (isNotBlank(commodityTypeId)) {
       result = createForCommodityType(tradeItems, commodityTypes, commodityTypeId, orderable,
-          profiler);
+              profiler);
     }
+
+    // Apply DON prefix matching — find donated equivalents
+    profiler.start("APPLY_DON_PREFIX_MATCHING");
+    result = applyDonPrefixMatching(orderable, result);
 
     profiler.stop().log();
     return result;
@@ -120,4 +125,54 @@ public class OrderableFulfillFactory {
     );
   }
 
+  /**
+   * Applies DON prefix matching to the OrderableFulfill result.
+   *
+   * <p>For a non-DON product (e.g. ABA003-TAB001-30), finds any donated equivalent
+   * (e.g. DON-ABA003-TAB001-30) and adds it to canFulfillForMe so NDSO can use
+   * donated stock to fulfill orders for the original product.
+   *
+   * <p>For a DON product, finds the original and adds it to canBeFulfilledByMe.
+   */
+  private OrderableFulfill applyDonPrefixMatching(Orderable orderable,
+                                                  OrderableFulfill existing) {
+    String productCode = orderable.getProductCode().toString();
+    boolean isDonProduct = productCode.toUpperCase().matches("^DON[^-]*-.*");
+
+    List<UUID> existingCanFulfillForMe = existing != null
+            ? Lists.newArrayList(existing.getCanFulfillForMe())
+            : Lists.newArrayList();
+    List<UUID> existingCanBeFulfilledByMe = existing != null
+            ? Lists.newArrayList(existing.getCanBeFulfilledByMe())
+            : Lists.newArrayList();
+
+    if (isDonProduct) {
+      // This is a DON product — find the original and add to canBeFulfilledByMe
+      // e.g. DON-ABA003-TAB001-30 → find ABA003-TAB001-30
+      String originalCode = productCode.replaceFirst("(?i)^DON[^-]*-", "");
+      List<Orderable> originals = orderableRepository
+              .findAllLatestByProductCodeLike(originalCode);
+      originals.forEach(o -> {
+        if (!existingCanBeFulfilledByMe.contains(o.getId())) {
+          existingCanBeFulfilledByMe.add(o.getId());
+        }
+      });
+    } else {
+      // This is an original product — find DON equivalents and add to canFulfillForMe
+      // e.g. ABA003-TAB001-30 → find DON%-ABA003-TAB001-30
+      List<Orderable> donEquivalents = orderableRepository
+              .findAllLatestByProductCodeLike("DON%-" + productCode);
+      donEquivalents.forEach(o -> {
+        if (!existingCanFulfillForMe.contains(o.getId())) {
+          existingCanFulfillForMe.add(o.getId());
+        }
+      });
+    }
+
+    if (existingCanFulfillForMe.isEmpty() && existingCanBeFulfilledByMe.isEmpty()) {
+      return existing;
+    }
+
+    return OrderableFulfill.of(existingCanFulfillForMe, existingCanBeFulfilledByMe);
+  }
 }


### PR DESCRIPTION
Problem
When NDSO opens the shipment screen to fulfill an order, the system only shows products that exactly match the ordered product code.
For example, if a facility ordered ABA003-TAB001-30 but the warehouse only has the donated equivalent DON-ABA003-TAB001-30 in stock, the donated product does not appear in the shipment screen at all — making it impossible for NDSO to fulfill the order even though the medicine is physically available in the warehouse.
The same problem exists in reverse — if a facility ordered a DON product but only the commercial equivalent has stock, NDSO cannot fulfill it.

Root Cause
The canFulfillForMe list built by OrderableFulfillFactory only considers formal trade item and commodity type relationships defined in the database. DON products have no formal relationship to their commercial equivalents, so they are never included in each other's fulfillment lists.

Solution
Added DON prefix matching logic to OrderableFulfillFactory that runs after the existing trade item/commodity type logic. For every product, the system now also searches for DON equivalents by product code pattern and includes them in the fulfillment lists.

For an original product (e.g. ABA003-TAB001-30): searches for any product matching DON%-ABA003-TAB001-30 and adds it to canFulfillForMe
For a DON product (e.g. DON-ABA003-TAB001-30): strips the DON prefix and finds the original product, adds it to canBeFulfilledByMe